### PR TITLE
ENH: Allow hounoring `--errors-for-leak-kinds` and print header

### DIFF
--- a/pytest_valgrind/valgrind.c
+++ b/pytest_valgrind/valgrind.c
@@ -28,11 +28,8 @@ do_leak_check(PyObject *self, PyObject *args)
     unsigned long leaked, dubious, reachable, suppressed;
 
     VALGRIND_DO_ADDED_LEAK_CHECK;
-
     VALGRIND_COUNT_LEAKS(leaked, dubious, reachable, suppressed);
 
-    /* Flush errors, we just assume they were all leaks. */
-    VALGRIND_COUNT_ERRORS;
     return PyLong_FromUnsignedLong(leaked);
 }
 


### PR DESCRIPTION
pytest-valgrind now honors `--errors-for-leak-kinds=definite`
(and potentially other settings). However, it only does if the
sanity check:

    do_leak_check()
    errors = get_valgrind_errors()
    obj = object()
    do_leak_check()
    new_errors = get_valgrind_errors() - errors

Reports no `new_errors`.

The problem is explained in a (too long) comment: Python's gc
allocates memory before each object which supports cyclic garbage
collection.  This is an "interior-pointer" in valgrind, which
valgrind considers a "possible" leak.  So, we have to ignore possible
leaks, but by default valgrind reports them as errors. This means
that the first version simply used the number of leaks instead of
the number of errors reported. Those "leaks" include "indirect" ones!

So, this is a bit of a funny trick where we ignore the errors reported
by default (to not break current, simple usage) and put the above
sanity check in case someone uses `--errors-for-leak-kinds=definite`.
If someone finds another way to make the check succeed, that would also
mean using the errors. (E.g. maybe someone patches valgrind to not
report Python Objects with cyclic GC support, which is probably easy, but
has to be done inside valgrind/memcheck itself!)